### PR TITLE
Detect API version automatically

### DIFF
--- a/dockerdns
+++ b/dockerdns
@@ -254,7 +254,7 @@ def main():
     QUIET = args.quiet
     resolver = () if args.no_recursion else args.resolver
     table = NameTable([(k + "." + args.domain, v) for (k, v) in args.record])
-    monitor = DockerMonitor(docker.Client(args.docker), table, args.domain)
+    monitor = DockerMonitor(docker.Client(args.docker, version='auto'), table, args.domain)
     dns = DnsServer(args.dns_bind, table, resolver)
     gevent.signal(signal.SIGINT, stop, dns) 
     dns.start()


### PR DESCRIPTION
http://docker-py.readthedocs.org/en/latest/api/#client-api allows using older API when talking to an older docker daemon