### PR TITLE
Reducing the docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM python:2.7-onbuild
+FROM python:2.7-slim
 MAINTAINER "Patrick Hensley <spaceboy@indirect.com>"
+RUN apt-get -qq update && \
+    apt-get -qqy install \
+    gcc && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ADD requirements.txt .
+RUN pip install -r requirements.txt
+ADD dockerdns .
 ENTRYPOINT ["./dockerdns"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:2.7-slim
+FROM alpine:3.1
 MAINTAINER "Patrick Hensley <spaceboy@indirect.com>"
-RUN apt-get -qq update && \
-    apt-get -qqy install \
-    gcc && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ADD requirements.txt .
-RUN pip install -r requirements.txt
+RUN PY=2.7.9-r0 && \
+    apk add --update python=$PY python-dev=$PY gcc libgcc libc-dev py-pip libev && \
+    pip install -r requirements.txt && \
+    apk del python-dev gcc libgcc libc-dev py-pip libev && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/apk/*
 ADD dockerdns .
 ENTRYPOINT ["./dockerdns"]


### PR DESCRIPTION
Love this utility - it is awesome. Thank you for writing it!
I think these changes reduce the image size by around 50%
phensley/docker-dns   latest              09804fbd4643        3 weeks ago         686.4 MB
docker-dns-small      latest              d0d3a549db43        17 minutes ago      312.3 MB
I am sure the image could get smaller still - but this seemed like a good first pass.

An alternative (safer approach) could be an additional dockerfile which builds a "slim" tag..