### PR TITLE
Hacking dockerdns to look in alternate location for IPAddress field.

### DIFF
--- a/dockerdns
+++ b/dockerdns
@@ -177,6 +177,8 @@ class DockerMonitor(object):
         labels = get(rec, 'Config', 'Labels')
         state = get(rec, 'State', 'Running')
         ip_address = get(rec, 'NetworkSettings', 'IPAddress')
+        if not ip_address:
+            ip_address = get(rec, 'NetworkSettings', 'Networks', 'macnet100', 'IPAddress')
 
         return [ Container(id_, name, state, ip_address) for name in self._get_names(name, labels) ]
 


### PR DESCRIPTION
I'm not entirely sure why, but my NetworkSettings do not contain an IP address directly, but instead have it as part of the Networks collection.  

I have been experimenting with the dev macvlan network, so this may be related.

My change is obviously specific to my setup, but I'm not a Python developer, so this is really just confirmation of an alternate location for the IP address.

What I see in the NetworkSettings node when I inspect a container:

```
"NetworkSettings": {
    // ...
    "IPAddress": "",
    // ...
    "Networks": {
	"macnet100": {
	    // ...
	    "IPAddress": "192.168.11.242",
	    // ...
	}
    }
}
```

Hope you can tweak your script.

Thanks!