### PR TITLE
Wildcard records

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ Now names not rooted in `example.com` will fail to resolve:
     root@4d15342387b0:/# ping github.com
     ping: unknown host github.com
 
+Pointing a subdomain to some IP
+
+    % docker run --name dns -v /var/run/docker.sock:/docker.sock phensley/dock$
+        --domain example.com --record localhost:127.0.0.1
+
+    # This will cause localhost.example.com to resolve to 127.0.0.1
+
+Pointing all subdomains to some IP
+
+    % docker run --name dns -v /var/run/docker.sock:/docker.sock phensley/doc$
+        --domain example.com --record *:172.18.0.4
+
+    # This makes everything not explicitly set as a subdomain to resolve to 172.18.0.4.
+    # Useful when your reverse proxy is there.
 
 License
 -------

--- a/dockerdns
+++ b/dockerdns
@@ -83,6 +83,8 @@ class NameTable(object):
             self.add(rec[0], rec[1])
 
     def add(self, name, addr):
+        if name.startswith('.'):
+            name = '*' + name
         key = self._key(name)
         if key:
             with self._lock:
@@ -94,10 +96,18 @@ class NameTable(object):
         if key:
             with self._lock:
                 res = self._storage.get(key)
-                if not res:
-                    log('table.get %s with NoneType' % (name))
-                else:
+
+                wild = re.sub(r'^[^\.]+', '*', name)
+                wildkey = self._key(wild)
+                wildres = self._storage.get(wildkey)
+
+                if res:
                     log('table.get %s with %s' % (name, ", ".join(addr for addr in res)))
+                elif wildres:
+                    log('table.get %s with %s' % (name, ", ".join(addr for addr in wildres)))
+                    res = wildres
+                else:
+                    log('table.get %s with NoneType' % (name))
                 return res
 
     def rename(self, old_name, new_name):
@@ -120,7 +130,8 @@ class NameTable(object):
 
     def _key(self, name):
         try:
-            return DNSLabel(name.lower()).label
+            label = DNSLabel(name.lower()).label
+            return label
         except Exception:
             return None
 
@@ -284,6 +295,7 @@ def check(args):
         if not os.path.exists(url.path):
             log('unix socket %r does not exist', url.path)
             sys.exit(1)
+
 
 def parse_args():
     docker_url = os.environ.get('DOCKER_HOST')


### PR DESCRIPTION
Thanks for your good work.

I added a feature that might be worth your consideration. I found it useful in an internal project.

This PR gives us the ability to say `--record :172.18.0.3` (notice the omission of the name) or `--record *:172.18.0.3` to point all traffic to subdomains specified by `--domain` to a specific IP address.

This is especially useful when using a reverse proxy and we want the same domain names available to the host to be available to the containers themselves too.
