### PR TITLE
Per-network resolution blacklisting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:latest
+FROM alpine:3.11
 MAINTAINER "Patrick Hensley <pathensley@gmail.com>"
 ADD requirements.txt .
-RUN apk add --update python python-dev gcc libgcc libc-dev py2-pip libev && \
+RUN apk add --update python python-dev g++ py2-pip libev && \
     pip install -r requirements.txt && \
-    apk del python-dev gcc libgcc libc-dev py2-pip libev && \
+    apk del python-dev g++ py2-pip libev && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/apk/*
 ADD dockerdns .

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Pointing all subdomains to some IP
     # This makes everything not explicitly set as a subdomain to resolve to 172.18.0.4.
     # Useful when your reverse proxy is there.
 
+You can also blacklist specific networks (space-separated) from the resolution table:
+
+    % docker run --name dns -v /var/run/docker.sock:/docker.sock \
+        -e NETWORK_BLACKLIST="172.18.0.0/16 172.19.0.0/16" phensley/docker-dns \
+        --domain example.com
+
+    # Useful when your network topology or firewall prevents clients from accessing some addresses.
+
 License
 -------
 

--- a/dockerdns
+++ b/dockerdns
@@ -38,6 +38,7 @@ import gevent
 from gevent import socket, threading
 from gevent.server import DatagramServer
 from gevent.resolver_ares import Resolver
+from ipaddress import ip_network, ip_address
 
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -53,6 +54,13 @@ EPILOG = '''
 
 '''
 
+network_blacklist = os.environ.get('NETWORK_BLACKLIST')
+if not network_blacklist:
+    network_blacklist = "255.255.255.255/32"
+
+network_blacklist = network_blacklist.split()
+for i, network in enumerate(network_blacklist):
+    network_blacklist[i] = ip_network(network)
 
 Container = namedtuple('Container', 'id, name, running, addrs')
 
@@ -91,6 +99,10 @@ class NameTable(object):
         key = self._key(name)
         if key:
             with self._lock:
+                for network in network_blacklist:
+                    if addr and ip_address(addr) in network:
+                        log('skipping table.add %s -> %s (blacklisted network)', name, addr)
+                        return
                 log('table.add %s -> %s', name, addr)
                 self._storage[key].add(addr)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dnslib==0.9.4
 future==0.15.2
 gevent==1.0.2
 docker-py==1.1.0
-
+py2-ipaddress==3.4.2


### PR DESCRIPTION
Support for per-network resolution blacklisting, preventing specific networks from being served as answers to DNS clients.

This originally came in useful to me in topologies where clients could not reach some containers on all of their addresses, thus making them unreachable.

This also includes a fix needed to keep building the Docker image on alpine with py2.